### PR TITLE
v.cluster: Modified code, now all workflow tests should pass

### DIFF
--- a/vector/v.cluster/test/v.cluster_test.py
+++ b/vector/v.cluster/test/v.cluster_test.py
@@ -1,13 +1,10 @@
-"""Module for testing v.cluster"""
-
-import pytest
 from grass.gunittest.case import TestCase
 from grass.gunittest.main import test
 from grass.script import core as grass
 
 
 class TestVCluster(TestCase):
-    """Test cases for v.cluster tool GRASS GIS"""
+    """Test cases for v.cluster tool in GRASS GIS."""
 
     @classmethod
     def setUpClass(cls):
@@ -24,8 +21,8 @@ class TestVCluster(TestCase):
         cls.runModule(
             "g.remove",
             type="vector",
-            name="""test_points,clustered,test_points_3d,clustered_3d
-            ,clustered_2d,clustered1,clustered2""",
+            name="test_points,clustered,test_points_3d,clustered_3d, \
+            clustered_2d,clustered1,clustered2",
             flags="f",
         )
 
@@ -83,7 +80,7 @@ class TestVCluster(TestCase):
 
     def test_invalid_method(self):
         """Test invalid clustering method."""
-        with pytest.raises(ValueError, match="This is an invalid method"):
+        with self.pytest.raises(ValueError):
             self.assertModule(
                 "v.cluster", input="test_points", output="clustered", method="invalid"
             )
@@ -136,9 +133,9 @@ class TestVCluster(TestCase):
         ), "There should be at least one cluster in the output."
 
     def test_2d_flag_effect(self):
-        """Test forcing flag produces different clusters from 3D clustering."""
+        """Test that clustering with -2 flag produces different clusters."""
 
-        # Run clustering in 3D
+        # Run clustering in 3D (default)
         self.assertModule(
             "v.cluster",
             input="test_points_3d",
@@ -196,10 +193,10 @@ class TestVCluster(TestCase):
                     cluster_id_2d = int(parts[2])
                     cluster_ids_2d.add(cluster_id_2d)
 
-        # If flag works, the of clusters should differ between 2D and 3D
+        # If the flag works, the number of clusters should differ
         assert len(cluster_ids_3d) != len(
             cluster_ids_2d
-        ), "2D clustering should produce different clusters than 3D."
+        ), "2D clustering should produce different clusters than 3D clustering"
 
 
 if __name__ == "__main__":

--- a/vector/v.cluster/test/v.cluster_test.py
+++ b/vector/v.cluster/test/v.cluster_test.py
@@ -6,7 +6,7 @@ from grass.script import core as grass
 
 
 class TestVCluster(TestCase):
-    """Test cases for v.cluster tool in GRASS GIS"""
+    """Test cases for v.cluster tool GRASS GIS"""
 
     @classmethod
     def setUpClass(cls):

--- a/vector/v.cluster/test/v.cluster_test.py
+++ b/vector/v.cluster/test/v.cluster_test.py
@@ -1,4 +1,5 @@
 """Module for testing v.cluster"""
+
 import pytest
 from grass.gunittest.case import TestCase
 from grass.gunittest.main import test
@@ -14,8 +15,7 @@ class TestVCluster(TestCase):
         cls.runModule("g.region", n=100, s=0, e=100, w=0, res=10)
         cls.runModule("v.random", output="test_points", npoints=200, seed=42)
         cls.runModule(
-            "v.random", output="test_points_3d", npoints=50, zmin=0, zmax=50,
-            seed=42
+            "v.random", output="test_points_3d", npoints=50, zmin=0, zmax=50, seed=42
         )
 
     @classmethod
@@ -85,8 +85,7 @@ class TestVCluster(TestCase):
         """Test invalid clustering method."""
         with pytest.raises(ValueError, match="This is an invalid method"):
             self.assertModule(
-                "v.cluster", input="test_points", output="clustered",
-                method="invalid"
+                "v.cluster", input="test_points", output="clustered", method="invalid"
             )
 
     def test_optics_clustering(self):
@@ -132,9 +131,9 @@ class TestVCluster(TestCase):
                     cluster_ids.add(cluster_id)
 
         # Assert that there is at least one cluster
-        assert len(cluster_ids) > 0, (
-            "There should be at least one cluster in the output."
-        )
+        assert (
+            len(cluster_ids) > 0
+        ), "There should be at least one cluster in the output."
 
     def test_2d_flag_effect(self):
         """Test forcing flag produces different clusters from 3D clustering."""
@@ -168,8 +167,7 @@ class TestVCluster(TestCase):
 
         # Export the clustered points to ASCII format
         ascii_output = grass.read_command(
-            "v.out.ascii", input="clustered_3d", format="point",
-            separator="comma"
+            "v.out.ascii", input="clustered_3d", format="point", separator="comma"
         )
 
         # Parse the ASCII output to extract cluster IDs
@@ -184,8 +182,7 @@ class TestVCluster(TestCase):
                     cluster_ids_3d.add(cluster_id_3d)
 
         ascii_output_2d = grass.read_command(
-            "v.out.ascii", input="clustered_2d", format="point",
-            separator="comma"
+            "v.out.ascii", input="clustered_2d", format="point", separator="comma"
         )
 
         # Parse the ASCII output to extract cluster IDs
@@ -200,9 +197,9 @@ class TestVCluster(TestCase):
                     cluster_ids_2d.add(cluster_id_2d)
 
         # If flag works, the of clusters should differ between 2D and 3D
-        assert len(cluster_ids_3d) != len(cluster_ids_2d), (
-            "2D clustering should produce different clusters than 3D."
-        )
+        assert len(cluster_ids_3d) != len(
+            cluster_ids_2d
+        ), "2D clustering should produce different clusters than 3D."
 
 
 if __name__ == "__main__":

--- a/vector/v.cluster/test/v.cluster_test.py
+++ b/vector/v.cluster/test/v.cluster_test.py
@@ -1,7 +1,9 @@
+"""Module for testing v.cluster"""
+import pytest
 from grass.gunittest.case import TestCase
 from grass.gunittest.main import test
 from grass.script import core as grass
-import pytest
+
 
 class TestVCluster(TestCase):
     """Test cases for v.cluster tool in GRASS GIS."""
@@ -11,103 +13,196 @@ class TestVCluster(TestCase):
         """Set up test environment by creating a sample vector points map."""
         cls.runModule("g.region", n=100, s=0, e=100, w=0, res=10)
         cls.runModule("v.random", output="test_points", npoints=200, seed=42)
-        cls.runModule("v.random", output="test_points_3d", npoints=50, zmin=0, zmax=50, seed=42)
+        cls.runModule(
+            "v.random", output="test_points_3d", npoints=50, zmin=0, zmax=50,
+            seed=42
+        )
 
     @classmethod
     def tearDownClass(cls):
         """Clean up test environment."""
-        cls.runModule("g.remove", type="vector", name="test_points,clustered,test_points_3d,clustered_3d,clustered_2d,clustered1,clustered2", flags="f")
+        cls.runModule(
+            "g.remove",
+            type="vector",
+            name="""test_points,clustered,test_points_3d,clustered_3d
+            ,clustered_2d,clustered1,clustered2""",
+            flags="f",
+        )
 
     def test_dbscan_clustering(self):
         """Test DBSCAN clustering with default parameters."""
-        self.assertModule("v.cluster", input="test_points", output="clustered", method="dbscan", distance=10, min=3, overwrite="true")
+        self.assertModule(
+            "v.cluster",
+            input="test_points",
+            output="clustered",
+            method="dbscan",
+            distance=10,
+            min=3,
+            overwrite="true",
+        )
         self.assertVectorExists("clustered")
-    
+
     def test_dbscan2_clustering(self):
         """Test DBSCAN2 clustering."""
-        self.assertModule("v.cluster", input="test_points", output="clustered", method="dbscan2", distance=10, min=3, overwrite="true")
+        self.assertModule(
+            "v.cluster",
+            input="test_points",
+            output="clustered",
+            method="dbscan2",
+            distance=10,
+            min=3,
+            overwrite="true",
+        )
         self.assertVectorExists("clustered")
 
     def test_optics2_clustering(self):
         """Test DBSCAN2 clustering."""
-        self.assertModule("v.cluster", input="test_points", output="clustered", method="optics2", distance=10, min=3, overwrite="true")
+        self.assertModule(
+            "v.cluster",
+            input="test_points",
+            output="clustered",
+            method="optics2",
+            distance=10,
+            min=3,
+            overwrite="true",
+        )
         self.assertVectorExists("clustered")
-    
+
     def test_density_clustering(self):
         """Test density clustering."""
-        self.assertModule("v.cluster", input="test_points", output="clustered", method="density", distance=10, min=3, overwrite="true")
+        self.assertModule(
+            "v.cluster",
+            input="test_points",
+            output="clustered",
+            method="density",
+            distance=10,
+            min=3,
+            overwrite="true",
+        )
         self.assertVectorExists("clustered")
 
     def test_invalid_method(self):
-        """Test invalid clustering method by ensuring only valid methods are accepted."""
-        with pytest.raises(ValueError):
-            self.assertModule("v.cluster", input="test_points", output="clustered", method="invalid")
-    
+        """Test invalid clustering method."""
+        with pytest.raises(ValueError, match="This is an invalid method"):
+            self.assertModule(
+                "v.cluster", input="test_points", output="clustered",
+                method="invalid"
+            )
+
     def test_optics_clustering(self):
         """Test OPTICS clustering."""
-        self.assertModule("v.cluster", input="test_points", output="clustered", method="optics", distance=10, min=3, overwrite="true")
+        self.assertModule(
+            "v.cluster",
+            input="test_points",
+            output="clustered",
+            method="optics",
+            distance=10,
+            min=3,
+            overwrite="true",
+        )
         self.assertVectorExists("clustered")
-        
+
     def test_at_least_one_cluster(self):
         """Test that there is at least one cluster in the output."""
-        self.assertModule("v.cluster", input="test_points", output="clustered", method="optics", distance=10, min=3, overwrite="true")
+        self.assertModule(
+            "v.cluster",
+            input="test_points",
+            output="clustered",
+            method="optics",
+            distance=10,
+            min=3,
+            overwrite="true",
+        )
         self.assertVectorExists("clustered")
-        
+
         # Export the clustered points to ASCII format
-        ascii_output = grass.read_command("v.out.ascii", input="clustered", format="point", separator="comma")
-        
+        ascii_output = grass.read_command(
+            "v.out.ascii", input="clustered", format="point", separator="comma"
+        )
+
         # Parse the ASCII output to extract cluster IDs
         cluster_ids = set()
         for line in ascii_output.splitlines():
             if line.strip():  # Skip empty lines
                 parts = line.split(",")
-                if len(parts) >= 3:  # Ensure the line has enough parts (x, y, z, cluster_id)
+                if (
+                    len(parts) >= 3
+                ):  # Ensure the line has enough parts (x, y, z, cluster_id)
                     cluster_id = int(parts[2])  # Cluster ID is the 4th column
                     cluster_ids.add(cluster_id)
-        
-        # Assert that there is at least one cluster
-        assert len(cluster_ids)> 0, "There should be at least one cluster in the output."
 
-    
+        # Assert that there is at least one cluster
+        assert len(cluster_ids) > 0, (
+            "There should be at least one cluster in the output."
+        )
+
     def test_2d_flag_effect(self):
-        """Test that forcing 2D clustering with -2 flag produces different clusters from 3D clustering."""
-        
+        """Test forcing flag produces different clusters from 3D clustering."""
+
         # Run clustering in 3D
-        self.assertModule("v.cluster", input="test_points_3d", output="clustered_3d", method="dbscan", distance=10, min=3, overwrite="true")
+        self.assertModule(
+            "v.cluster",
+            input="test_points_3d",
+            output="clustered_3d",
+            method="dbscan",
+            distance=10,
+            min=3,
+            overwrite="true",
+        )
 
         # Run clustering in 2D (force ignoring Z)
-        self.assertModule("v.cluster", input="test_points_3d", output="clustered_2d", method="dbscan", distance=10, min=3, flags="2", overwrite="true")
+        self.assertModule(
+            "v.cluster",
+            input="test_points_3d",
+            output="clustered_2d",
+            method="dbscan",
+            distance=10,
+            min=3,
+            flags="2",
+            overwrite="true",
+        )
 
         # Ensure both outputs exist
         self.assertVectorExists("clustered_3d")
         self.assertVectorExists("clustered_2d")
 
         # Export the clustered points to ASCII format
-        ascii_output = grass.read_command("v.out.ascii", input="clustered_3d", format="point", separator="comma")
-        
+        ascii_output = grass.read_command(
+            "v.out.ascii", input="clustered_3d", format="point",
+            separator="comma"
+        )
+
         # Parse the ASCII output to extract cluster IDs
         cluster_ids_3d = set()
         for line in ascii_output.splitlines():
             if line.strip():  # Skip empty lines
                 parts = line.split(",")
-                if len(parts) >= 4:  # Ensure the line has enough parts (x, y, z, cluster_id)
-                    cluster_id_3d = int(parts[3])  # Cluster ID is the 4th column
+                if (
+                    len(parts) >= 4
+                ):  # Ensure the line has enough parts (x, y, z, cluster_id)
+                    cluster_id_3d = int(parts[3])
                     cluster_ids_3d.add(cluster_id_3d)
-        
-        ascii_output_2d = grass.read_command("v.out.ascii", input="clustered_2d", format="point", separator="comma")
-        
+
+        ascii_output_2d = grass.read_command(
+            "v.out.ascii", input="clustered_2d", format="point",
+            separator="comma"
+        )
+
         # Parse the ASCII output to extract cluster IDs
         cluster_ids_2d = set()
         for line in ascii_output_2d.splitlines():
             if line.strip():  # Skip empty lines
                 parts = line.split(",")
-                if len(parts) >= 3:  # Ensure the line has enough parts (x, y, z, cluster_id)
-                    cluster_id_2d = int(parts[2])  # Cluster ID is the 4th column
+                if (
+                    len(parts) >= 3
+                ):  # Ensure the line has enough parts (x, y, z, cluster_id)
+                    cluster_id_2d = int(parts[2])
                     cluster_ids_2d.add(cluster_id_2d)
 
         # If flag works, the of clusters should differ between 2D and 3D
-        assert len(cluster_ids_3d) != len(cluster_ids_2d), "2D clustering should produce different clusters than 3D clustering."
-
+        assert len(cluster_ids_3d) != len(cluster_ids_2d), (
+            "2D clustering should produce different clusters than 3D."
+        )
 
 
 if __name__ == "__main__":

--- a/vector/v.cluster/test/v.cluster_test.py
+++ b/vector/v.cluster/test/v.cluster_test.py
@@ -6,7 +6,7 @@ from grass.script import core as grass
 
 
 class TestVCluster(TestCase):
-    """Test cases for v.cluster tool in GRASS GIS."""
+    """Test cases for v.cluster tool in GRASS GIS"""
 
     @classmethod
     def setUpClass(cls):

--- a/vector/v.cluster/test/v.cluster_test.py
+++ b/vector/v.cluster/test/v.cluster_test.py
@@ -74,7 +74,7 @@ class TestVCluster(TestCase):
     def test_2d_flag_effect(self):
         """Test that forcing 2D clustering with -2 flag produces different clusters from 3D clustering."""
         
-        # Run clustering in 3D (default)
+        # Run clustering in 3D 
         self.assertModule("v.cluster", input="test_points_3d", output="clustered_3d", method="dbscan", distance=10, min=3, overwrite="true")
 
         # Run clustering in 2D (force ignoring Z)

--- a/vector/v.cluster/test/v.cluster_test.py
+++ b/vector/v.cluster/test/v.cluster_test.py
@@ -105,7 +105,7 @@ class TestVCluster(TestCase):
                     cluster_id_2d = int(parts[2])  # Cluster ID is the 4th column
                     cluster_ids_2d.add(cluster_id_2d)
 
-        # If flag works, the number of clusters should differ between 2D and 3D
+        # If flag works, the of clusters should differ between 2D and 3D
         assert len(cluster_ids_3d) != len(cluster_ids_2d), "2D clustering should produce different clusters than 3D clustering."
 
 

--- a/vector/v.cluster/test/v.cluster_test.py
+++ b/vector/v.cluster/test/v.cluster_test.py
@@ -105,7 +105,7 @@ class TestVCluster(TestCase):
                     cluster_id_2d = int(parts[2])  # Cluster ID is the 4th column
                     cluster_ids_2d.add(cluster_id_2d)
 
-        # If the flag works, the number of clusters should differ between 2D and 3D
+        # If flag works, the number of clusters should differ between 2D and 3D
         assert len(cluster_ids_3d) != len(cluster_ids_2d), "2D clustering should produce different clusters than 3D clustering."
 
 

--- a/vector/v.cluster/test/v.cluster_test.py
+++ b/vector/v.cluster/test/v.cluster_test.py
@@ -1,9 +1,7 @@
-import os
-import unittest
 from grass.gunittest.case import TestCase
 from grass.gunittest.main import test
 from grass.script import core as grass
-from grass.script import vector as gvector
+import pytest
 
 class TestVCluster(TestCase):
     """Test cases for v.cluster tool in GRASS GIS."""
@@ -22,37 +20,37 @@ class TestVCluster(TestCase):
 
     def test_dbscan_clustering(self):
         """Test DBSCAN clustering with default parameters."""
-        self.assertModule("v.cluster", input="test_points", output="clustered", method="dbscan", distance=10, min=3, overwrite = "true")
+        self.assertModule("v.cluster", input="test_points", output="clustered", method="dbscan", distance=10, min=3, overwrite="true")
         self.assertVectorExists("clustered")
     
     def test_dbscan2_clustering(self):
         """Test DBSCAN2 clustering."""
-        self.assertModule("v.cluster", input="test_points", output="clustered", method="dbscan2", distance=10, min=3, overwrite = "true")
+        self.assertModule("v.cluster", input="test_points", output="clustered", method="dbscan2", distance=10, min=3, overwrite="true")
         self.assertVectorExists("clustered")
 
     def test_optics2_clustering(self):
         """Test DBSCAN2 clustering."""
-        self.assertModule("v.cluster", input="test_points", output="clustered", method="optics2", distance=10, min=3, overwrite = "true")
+        self.assertModule("v.cluster", input="test_points", output="clustered", method="optics2", distance=10, min=3, overwrite="true")
         self.assertVectorExists("clustered")
     
     def test_density_clustering(self):
         """Test density clustering."""
-        self.assertModule("v.cluster", input="test_points", output="clustered", method="density", distance=10, min=3, overwrite = "true")
+        self.assertModule("v.cluster", input="test_points", output="clustered", method="density", distance=10, min=3, overwrite="true")
         self.assertVectorExists("clustered")
 
     def test_invalid_method(self):
         """Test invalid clustering method by ensuring only valid methods are accepted."""
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             self.assertModule("v.cluster", input="test_points", output="clustered", method="invalid")
     
     def test_optics_clustering(self):
         """Test OPTICS clustering."""
-        self.assertModule("v.cluster", input="test_points", output="clustered", method="optics", distance=10, min=3, overwrite = "true")
+        self.assertModule("v.cluster", input="test_points", output="clustered", method="optics", distance=10, min=3, overwrite="true")
         self.assertVectorExists("clustered")
         
     def test_at_least_one_cluster(self):
         """Test that there is at least one cluster in the output."""
-        self.assertModule("v.cluster", input="test_points", output="clustered", method="optics", distance=10, min=3, overwrite = "true")
+        self.assertModule("v.cluster", input="test_points", output="clustered", method="optics", distance=10, min=3, overwrite="true")
         self.assertVectorExists("clustered")
         
         # Export the clustered points to ASCII format
@@ -68,17 +66,17 @@ class TestVCluster(TestCase):
                     cluster_ids.add(cluster_id)
         
         # Assert that there is at least one cluster
-        self.assertGreater(len(cluster_ids), 0, "There should be at least one cluster in the output.")
+        assert len(cluster_ids)> 0, "There should be at least one cluster in the output."
 
     
     def test_2d_flag_effect(self):
         """Test that forcing 2D clustering with -2 flag produces different clusters from 3D clustering."""
         
-        # Run clustering in 3D 
+        # Run clustering in 3D
         self.assertModule("v.cluster", input="test_points_3d", output="clustered_3d", method="dbscan", distance=10, min=3, overwrite="true")
 
         # Run clustering in 2D (force ignoring Z)
-        self.assertModule("v.cluster", input="test_points_3d", output="clustered_2d", method="dbscan", distance=10, min=3,flags="2", overwrite="true")
+        self.assertModule("v.cluster", input="test_points_3d", output="clustered_2d", method="dbscan", distance=10, min=3, flags="2", overwrite="true")
 
         # Ensure both outputs exist
         self.assertVectorExists("clustered_3d")
@@ -108,7 +106,7 @@ class TestVCluster(TestCase):
                     cluster_ids_2d.add(cluster_id_2d)
 
         # If the flag works, the number of clusters should differ between 2D and 3D
-        self.assertNotEqual(len(cluster_ids_3d), len(cluster_ids_2d), "2D clustering should produce different clusters than 3D clustering.")
+        assert len(cluster_ids_3d) != len(cluster_ids_2d), "2D clustering should produce different clusters than 3D clustering."
 
 
 


### PR DESCRIPTION
Description

This pull request adds test cases for the v.cluster tool in GRASS GIS. The tests cover various clustering methods, including DBSCAN, DBSCAN2, OPTICS, OPTICS2, and density-based clustering. Additionally, it verifies proper handling of invalid methods and ensures that at least one cluster is generated in the output.

Motivation and context

The v.cluster tool is essential for spatial clustering in GRASS GIS. These tests ensure its reliability and correctness across different clustering methods. The changes improve test coverage and help maintain the integrity of clustering functionalities.

How has this been tested?

The following tests were conducted:

Verified DBSCAN, DBSCAN2, OPTICS, OPTICS2, and density clustering produce expected outputs.

Checked that an invalid clustering method raises an error.

Confirmed that at least one cluster is present in the results.

Compared results of 2D clustering (with -2 flag) and 3D clustering to ensure different cluster IDs are generated.

Screenshots (if appropriate)

N/A

Types of changes
Code modified, to pass the python code quality check

Checklist

<!-- See the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, please ask. We're here to help! -->
- [ ] PR title provides summary of the changes and starts with one of the
[pre-defined prefixes](../../utils/release.yml)
<!-- For example: "doc: Add example to db.describe documentation" -->
<!-- or if it is a fix use "db.describe: fix JSON output format" -->
- [ ] My code follows the [code style](../../doc/development/style_guide.md)
of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.