### PR TITLE
v.cluster: Made changes

### DIFF
--- a/vector/v.cluster/test/v.cluster_test.py
+++ b/vector/v.cluster/test/v.cluster_test.py
@@ -1,9 +1,7 @@
-import os
-import unittest
 from grass.gunittest.case import TestCase
 from grass.gunittest.main import test
 from grass.script import core as grass
-from grass.script import vector as gvector
+
 
 class TestVCluster(TestCase):
     """Test cases for v.cluster tool in GRASS GIS."""
@@ -13,103 +11,192 @@ class TestVCluster(TestCase):
         """Set up test environment by creating a sample vector points map."""
         cls.runModule("g.region", n=100, s=0, e=100, w=0, res=10)
         cls.runModule("v.random", output="test_points", npoints=200, seed=42)
-        cls.runModule("v.random", output="test_points_3d", npoints=50, zmin=0, zmax=50, seed=42)
+        cls.runModule(
+            "v.random", output="test_points_3d", npoints=50, zmin=0, zmax=50, seed=42
+        )
 
     @classmethod
     def tearDownClass(cls):
         """Clean up test environment."""
-        cls.runModule("g.remove", type="vector", name="test_points,clustered,test_points_3d,clustered_3d,clustered_2d,clustered1,clustered2", flags="f")
+        cls.runModule(
+            "g.remove",
+            type="vector",
+            name="test_points,clustered,test_points_3d,clustered_3d, \
+            clustered_2d,clustered1,clustered2",
+            flags="f",
+        )
 
     def test_dbscan_clustering(self):
         """Test DBSCAN clustering with default parameters."""
-        self.assertModule("v.cluster", input="test_points", output="clustered", method="dbscan", distance=10, min=3, overwrite = "true")
+        self.assertModule(
+            "v.cluster",
+            input="test_points",
+            output="clustered",
+            method="dbscan",
+            distance=10,
+            min=3,
+            overwrite="true",
+        )
         self.assertVectorExists("clustered")
-    
+
     def test_dbscan2_clustering(self):
         """Test DBSCAN2 clustering."""
-        self.assertModule("v.cluster", input="test_points", output="clustered", method="dbscan2", distance=10, min=3, overwrite = "true")
+        self.assertModule(
+            "v.cluster",
+            input="test_points",
+            output="clustered",
+            method="dbscan2",
+            distance=10,
+            min=3,
+            overwrite="true",
+        )
         self.assertVectorExists("clustered")
 
     def test_optics2_clustering(self):
         """Test DBSCAN2 clustering."""
-        self.assertModule("v.cluster", input="test_points", output="clustered", method="optics2", distance=10, min=3, overwrite = "true")
+        self.assertModule(
+            "v.cluster",
+            input="test_points",
+            output="clustered",
+            method="optics2",
+            distance=10,
+            min=3,
+            overwrite="true",
+        )
         self.assertVectorExists("clustered")
-    
+
     def test_density_clustering(self):
         """Test density clustering."""
-        self.assertModule("v.cluster", input="test_points", output="clustered", method="density", distance=10, min=3, overwrite = "true")
+        self.assertModule(
+            "v.cluster",
+            input="test_points",
+            output="clustered",
+            method="density",
+            distance=10,
+            min=3,
+            overwrite="true",
+        )
         self.assertVectorExists("clustered")
 
     def test_invalid_method(self):
-        """Test invalid clustering method by ensuring only valid methods are accepted."""
-        with self.assertRaises(ValueError):
-            self.assertModule("v.cluster", input="test_points", output="clustered", method="invalid")
-    
+        """Test invalid clustering method."""
+        with self.pytest.raises(ValueError):
+            self.assertModule(
+                "v.cluster", input="test_points", output="clustered", method="invalid"
+            )
+
     def test_optics_clustering(self):
         """Test OPTICS clustering."""
-        self.assertModule("v.cluster", input="test_points", output="clustered", method="optics", distance=10, min=3, overwrite = "true")
+        self.assertModule(
+            "v.cluster",
+            input="test_points",
+            output="clustered",
+            method="optics",
+            distance=10,
+            min=3,
+            overwrite="true",
+        )
         self.assertVectorExists("clustered")
-        
+
     def test_at_least_one_cluster(self):
         """Test that there is at least one cluster in the output."""
-        self.assertModule("v.cluster", input="test_points", output="clustered", method="optics", distance=10, min=3, overwrite = "true")
+        self.assertModule(
+            "v.cluster",
+            input="test_points",
+            output="clustered",
+            method="optics",
+            distance=10,
+            min=3,
+            overwrite="true",
+        )
         self.assertVectorExists("clustered")
-        
+
         # Export the clustered points to ASCII format
-        ascii_output = grass.read_command("v.out.ascii", input="clustered", format="point", separator="comma")
-        
+        ascii_output = grass.read_command(
+            "v.out.ascii", input="clustered", format="point", separator="comma"
+        )
+
         # Parse the ASCII output to extract cluster IDs
         cluster_ids = set()
         for line in ascii_output.splitlines():
             if line.strip():  # Skip empty lines
                 parts = line.split(",")
-                if len(parts) >= 3:  # Ensure the line has enough parts (x, y, z, cluster_id)
+                if (
+                    len(parts) >= 3
+                ):  # Ensure the line has enough parts (x, y, z, cluster_id)
                     cluster_id = int(parts[2])  # Cluster ID is the 4th column
                     cluster_ids.add(cluster_id)
-        
-        # Assert that there is at least one cluster
-        self.assertGreater(len(cluster_ids), 0, "There should be at least one cluster in the output.")
 
-    
+        # Assert that there is at least one cluster
+        assert len(cluster_ids) > 0, (
+            "There should be at least one cluster in the output."
+        )
+
     def test_2d_flag_effect(self):
-        """Test that forcing 2D clustering with -2 flag produces different clusters from 3D clustering."""
-        
+        """Test that clustering with -2 flag produces different clusters."""
+
         # Run clustering in 3D (default)
-        self.assertModule("v.cluster", input="test_points_3d", output="clustered_3d", method="dbscan", distance=10, min=3, overwrite="true")
+        self.assertModule(
+            "v.cluster",
+            input="test_points_3d",
+            output="clustered_3d",
+            method="dbscan",
+            distance=10,
+            min=3,
+            overwrite="true",
+        )
 
         # Run clustering in 2D (force ignoring Z)
-        self.assertModule("v.cluster", input="test_points_3d", output="clustered_2d", method="dbscan", distance=10, min=3,flags="2", overwrite="true")
+        self.assertModule(
+            "v.cluster",
+            input="test_points_3d",
+            output="clustered_2d",
+            method="dbscan",
+            distance=10,
+            min=3,
+            flags="2",
+            overwrite="true",
+        )
 
         # Ensure both outputs exist
         self.assertVectorExists("clustered_3d")
         self.assertVectorExists("clustered_2d")
 
         # Export the clustered points to ASCII format
-        ascii_output = grass.read_command("v.out.ascii", input="clustered_3d", format="point", separator="comma")
-        
+        ascii_output = grass.read_command(
+            "v.out.ascii", input="clustered_3d", format="point", separator="comma"
+        )
+
         # Parse the ASCII output to extract cluster IDs
         cluster_ids_3d = set()
         for line in ascii_output.splitlines():
             if line.strip():  # Skip empty lines
                 parts = line.split(",")
-                if len(parts) >= 4:  # Ensure the line has enough parts (x, y, z, cluster_id)
-                    cluster_id_3d = int(parts[3])  # Cluster ID is the 4th column
+                if (
+                    len(parts) >= 4
+                ):  # Ensure the line has enough parts (x, y, z, cluster_id)
+                    cluster_id_3d = int(parts[3])
                     cluster_ids_3d.add(cluster_id_3d)
-        
-        ascii_output_2d = grass.read_command("v.out.ascii", input="clustered_2d", format="point", separator="comma")
-        
+
+        ascii_output_2d = grass.read_command(
+            "v.out.ascii", input="clustered_2d", format="point", separator="comma"
+        )
+
         # Parse the ASCII output to extract cluster IDs
         cluster_ids_2d = set()
         for line in ascii_output_2d.splitlines():
             if line.strip():  # Skip empty lines
                 parts = line.split(",")
-                if len(parts) >= 3:  # Ensure the line has enough parts (x, y, z, cluster_id)
-                    cluster_id_2d = int(parts[2])  # Cluster ID is the 4th column
+                if (
+                    len(parts) >= 3
+                ):  # Ensure the line has enough parts (x, y, z, cluster_id)
+                    cluster_id_2d = int(parts[2])
                     cluster_ids_2d.add(cluster_id_2d)
 
-        # If the flag works, the number of clusters should differ between 2D and 3D
-        self.assertNotEqual(len(cluster_ids_3d), len(cluster_ids_2d), "2D clustering should produce different clusters than 3D clustering.")
-
+        # If the flag works, the number of clusters should differ
+        assert len(cluster_ids_3d) != len(cluster_ids_2d), (
+            "2D clustering to produce different clusters than 3D clustering"
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Description

This pull request adds test cases for the v.cluster tool in GRASS GIS. The tests cover various clustering methods, including DBSCAN, DBSCAN2, OPTICS, OPTICS2, and density-based clustering. Additionally, it verifies proper handling of invalid methods and ensures that at least one cluster is generated in the output.

Motivation and context

The v.cluster tool is essential for spatial clustering in GRASS GIS. These tests ensure its reliability and correctness across different clustering methods. The changes improve test coverage and help maintain the integrity of clustering functionalities.

How has this been tested?

The following tests were conducted:

Verified DBSCAN, DBSCAN2, OPTICS, OPTICS2, and density clustering produce expected outputs.

Checked that an invalid clustering method raises an error.

Confirmed that at least one cluster is present in the results.

Compared results of 2D clustering (with -2 flag) and 3D clustering to ensure different cluster IDs are generated.

Screenshots (if appropriate)

N/A

Types of changes
Code modified, to pass the python code quality check

Checklist
<!-- See the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, please ask. We're here to help! -->
- [ ] PR title provides summary of the changes and starts with one of the
[pre-defined prefixes](../../utils/release.yml)
<!-- For example: "doc: Add example to db.describe documentation" -->
<!-- or if it is a fix use "db.describe: fix JSON output format" -->
- [ ] My code follows the [code style](../../doc/development/style_guide.md)
of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.